### PR TITLE
Update cert-manager version to 1.3.1 from 0.15.1

### DIFF
--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -6,7 +6,7 @@ weight: 10
 
 
 
-The operator installs the 2.5.0 version of Apache Kafka, and can run on Minikube v0.33.1+ and Kubernetes 1.15.0+.
+The operator installs the 2.7.0 version of Apache Kafka, and can run on Minikube v0.33.1+ and Kubernetes 1.18.0+.
 
 > The operator supports Kafka 2.0+
 
@@ -40,7 +40,7 @@ The Kafka operator uses [cert-manager](https://cert-manager.io) for issuing cert
 
 > Note:
 >
-> - Kafka operator 0.8.x and newer supports cert-manager 0.15.x
+> - Kafka operator 0.8.x and newer supports cert-manager 1.3.x
 > - Kafka operator 0.7.x supports cert-manager 0.10.x
 
 Install cert-manager and the CustomResourceDefinitions using one of the following methods:
@@ -49,7 +49,7 @@ Install cert-manager and the CustomResourceDefinitions using one of the followin
 
     ```bash
     # Install the CustomResourceDefinitions and cert-manager itself
-    kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.15.2/cert-manager.yaml
+    kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
     ```
 
 - Using Helm:
@@ -62,10 +62,10 @@ Install cert-manager and the CustomResourceDefinitions using one of the followin
 
     # Install cert-manager into the cluster
     # Using helm3
-    helm install cert-manager --namespace cert-manager --create-namespace --version v0.15.2 jetstack/cert-manager
+    helm install cert-manager --namespace cert-manager --create-namespace --version v1.3.1 jetstack/cert-manager
 
     # Install the CustomResourceDefinitions
-    kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.2/cert-manager.crds.yaml
+    kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.crds.yaml
 
 Verify that the cert-manager pods have been created:
 


### PR DESCRIPTION
This PR updates the cert manager to 1.3.1 and bumps the supported k8s version with the installed kafka version.