### PR TITLE
Apache operator renaming

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -8,7 +8,7 @@ cascade:
   operatorName: "Koperator"
 ---
 
-The {{< kafka-operator >}} (formerly called Kafka Operator) is a Kubernetes operator to automate provisioning, management, autoscaling and operations of [Apache Kafka](https://kafka.apache.org) clusters deployed to K8s.
+The {{< kafka-operator >}} (formerly called Banzai Cloud Kafka Operator) is a Kubernetes operator to automate provisioning, management, autoscaling and operations of [Apache Kafka](https://kafka.apache.org) clusters deployed to K8s.
 
 ## Overview
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,13 +1,14 @@
 ---
-title: Kafka operator
+title: Kafka Operator
 img: /docs/supertubes/kafka-operator/img/kafka-operator-arch.png
 weight: 700
 cascade:
   module: kafka-operator
   githubEditUrl: "https://github.com/banzaicloud/kafka-operator-docs/edit/master/docs/"
+  operatorName: "Kafka Operator"
 ---
 
-The Banzai Cloud Kafka operator is a Kubernetes operator to automate provisioning, management, autoscaling and operations of [Apache Kafka](https://kafka.apache.org) clusters deployed to K8s.
+The Banzai Cloud {{< kafka-operator >}} is a Kubernetes operator to automate provisioning, management, autoscaling and operations of [Apache Kafka](https://kafka.apache.org) clusters deployed to K8s.
 
 ## Overview
 
@@ -25,7 +26,7 @@ The Banzai Cloud Kafka operator is a Kubernetes operator to automate provisionin
 
 ![Kafka-operator architecture](./img/kafka-operator-arch.png)
 
->We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which were driving us to create the Banzai Cloud Kafka operator.
+>We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which were driving us to create the Banzai Cloud {{< kafka-operator >}}.
 
 {{% include-headless "doc/kafka-operator-supertubes-intro.md" %}}
 
@@ -34,6 +35,6 @@ The Banzai Cloud Kafka operator is a Kubernetes operator to automate provisionin
 At [Banzai Cloud](https://banzaicloud.com) we are building a Kubernetes distribution, [PKE](/products/pke/), and a hybrid-cloud container management platform, [Pipeline](/products/pipeline/), that operate Kafka clusters (among other types) for our customers. Apache Kafka predates Kubernetes and was designed mostly for `static` on-premise environments. State management, node identity, failover, etc all come part and parcel with Kafka, so making it work properly on Kubernetes and on an underlying dynamic environment can be a challenge.
 
 There are already several approaches to operating Kafka on Kubernetes, however, we did not find them appropriate for use in a highly dynamic environment, nor capable of meeting our customers' needs. At the same time, there is substantial interest within the Kafka community for a solution which enables Kafka on Kubernetes, both in the open source and closed source space.
->We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which were driving us to create the Banzai Cloud Kafka operator.
+>We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which were driving us to create the Banzai Cloud {{< kafka-operator >}}.
 
 Finally, our motivation is to build an open source solution and a community which drives the innovation and features of this operator. We are long term contributors and active community members of both Apache Kafka and Kubernetes, and we hope to recreate a similar community around this operator.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -34,7 +34,10 @@ The Banzai Cloud {{< kafka-operator >}} (formerly called Kafka Operator) is a Ku
 
 At [Banzai Cloud](https://banzaicloud.com) we are building a Kubernetes distribution, [PKE](/products/pke/), and a hybrid-cloud container management platform, [Pipeline](/products/pipeline/), that operate Kafka clusters (among other types) for our customers. Apache Kafka predates Kubernetes and was designed mostly for `static` on-premise environments. State management, node identity, failover, etc all come part and parcel with Kafka, so making it work properly on Kubernetes and on an underlying dynamic environment can be a challenge.
 
-There are already several approaches to operating Kafka on Kubernetes, however, we did not find them appropriate for use in a highly dynamic environment, nor capable of meeting our customers' needs. At the same time, there is substantial interest within the Kafka community for a solution which enables Kafka on Kubernetes, both in the open source and closed source space.
+There are already several approaches to operating Apache Kafka on Kubernetes, however, we did not find them appropriate for use in a highly dynamic environment, nor capable of meeting our customers' needs. At the same time, there is substantial interest within the Kafka community for a solution which enables Kafka on Kubernetes, both in the open source and closed source space.
 >We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which were driving us to create the Banzai Cloud {{< kafka-operator >}}.
 
 Finally, our motivation is to build an open source solution and a community which drives the innovation and features of this operator. We are long term contributors and active community members of both Apache Kafka and Kubernetes, and we hope to recreate a similar community around this operator.
+
+---
+Apache Kafka, Kafka, and the Kafka logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -32,7 +32,7 @@ The Banzai Cloud {{< kafka-operator >}} (formerly called Kafka Operator) is a Ku
 
 ## Motivation
 
-At [Banzai Cloud](https://banzaicloud.com) we are building a Kubernetes distribution, [PKE](/products/pke/), and a hybrid-cloud container management platform, [Pipeline](/products/pipeline/), that operate Kafka clusters (among other types) for our customers. Apache Kafka predates Kubernetes and was designed mostly for `static` on-premise environments. State management, node identity, failover, etc all come part and parcel with Kafka, so making it work properly on Kubernetes and on an underlying dynamic environment can be a challenge.
+Apache Kafka predates Kubernetes and was designed mostly for `static` on-premise environments. State management, node identity, failover, etc all come part and parcel with Kafka, so making it work properly on Kubernetes and on an underlying dynamic environment can be a challenge.
 
 There are already several approaches to operating Apache Kafka on Kubernetes, however, we did not find them appropriate for use in a highly dynamic environment, nor capable of meeting our customers' needs. At the same time, there is substantial interest within the Kafka community for a solution which enables Kafka on Kubernetes, both in the open source and closed source space.
 >We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which were driving us to create the Banzai Cloud {{< kafka-operator >}}.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -8,7 +8,7 @@ cascade:
   operatorName: "Koperator"
 ---
 
-The Banzai Cloud {{< kafka-operator >}} (formerly called Kafka Operator) is a Kubernetes operator to automate provisioning, management, autoscaling and operations of [Apache Kafka](https://kafka.apache.org) clusters deployed to K8s.
+The {{< kafka-operator >}} (formerly called Kafka Operator) is a Kubernetes operator to automate provisioning, management, autoscaling and operations of [Apache Kafka](https://kafka.apache.org) clusters deployed to K8s.
 
 ## Overview
 
@@ -26,7 +26,7 @@ The Banzai Cloud {{< kafka-operator >}} (formerly called Kafka Operator) is a Ku
 
 ![Kafka-operator architecture](./img/kafka-operator-arch.png)
 
->We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which were driving us to create the Banzai Cloud {{< kafka-operator >}}.
+>We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which drove us to create the {{< kafka-operator >}}.
 
 {{% include-headless "doc/kafka-operator-supertubes-intro.md" %}}
 
@@ -35,7 +35,7 @@ The Banzai Cloud {{< kafka-operator >}} (formerly called Kafka Operator) is a Ku
 Apache Kafka predates Kubernetes and was designed mostly for `static` on-premise environments. State management, node identity, failover, etc all come part and parcel with Kafka, so making it work properly on Kubernetes and on an underlying dynamic environment can be a challenge.
 
 There are already several approaches to operating Apache Kafka on Kubernetes, however, we did not find them appropriate for use in a highly dynamic environment, nor capable of meeting our customers' needs. At the same time, there is substantial interest within the Kafka community for a solution which enables Kafka on Kubernetes, both in the open source and closed source space.
->We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which were driving us to create the Banzai Cloud {{< kafka-operator >}}.
+>We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which were driving us to create the {{< kafka-operator >}}.
 
 Finally, our motivation is to build an open source solution and a community which drives the innovation and features of this operator. We are long term contributors and active community members of both Apache Kafka and Kubernetes, and we hope to recreate a similar community around this operator.
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -8,7 +8,7 @@ cascade:
   operatorName: "Kafka Operator"
 ---
 
-The Banzai Cloud {{< kafka-operator >}} is a Kubernetes operator to automate provisioning, management, autoscaling and operations of [Apache Kafka](https://kafka.apache.org) clusters deployed to K8s.
+The Banzai Cloud {{< kafka-operator >}} (formerly called Kafka Operator) is a Kubernetes operator to automate provisioning, management, autoscaling and operations of [Apache Kafka](https://kafka.apache.org) clusters deployed to K8s.
 
 ## Overview
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Kafka Operator
+title: Koperator
 img: /docs/supertubes/kafka-operator/img/kafka-operator-arch.png
 weight: 700
 cascade:

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -5,7 +5,7 @@ weight: 700
 cascade:
   module: kafka-operator
   githubEditUrl: "https://github.com/banzaicloud/kafka-operator-docs/edit/master/docs/"
-  operatorName: "Kafka Operator"
+  operatorName: "Koperator"
 ---
 
 The Banzai Cloud {{< kafka-operator >}} (formerly called Kafka Operator) is a Kubernetes operator to automate provisioning, management, autoscaling and operations of [Apache Kafka](https://kafka.apache.org) clusters deployed to K8s.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -12,7 +12,7 @@ The {{< kafka-operator >}} (formerly called Kafka Operator) is a Kubernetes oper
 
 ## Overview
 
-[Apache Kafka](https://kafka.apache.org) is an open-source distributed streaming platform, and some of the main features of the **Kafka-operator** are:
+[Apache Kafka](https://kafka.apache.org) is an open-source distributed streaming platform, and some of the main features of the **{{< kafka-operator >}}** are:
 
 - the provisioning of secure and production-ready Kafka clusters
 - **fine grained** broker configuration support
@@ -24,7 +24,7 @@ The {{< kafka-operator >}} (formerly called Kafka Operator) is a Kubernetes oper
 - graceful rolling upgrade
 - advanced topic and user management via CRD
 
-![Kafka-operator architecture](./img/kafka-operator-arch.png)
+![{{< kafka-operator >}} architecture](./img/kafka-operator-arch.png)
 
 >We took a different approach to what's out there - we believe for a good reason - please read on to understand more about our [design motivations](features/) and some of the [scenarios](scenarios/) which drove us to create the {{< kafka-operator >}}.
 

--- a/docs/benchmarks/_index.md
+++ b/docs/benchmarks/_index.md
@@ -33,7 +33,7 @@ banzai login
     banzai cluster create
     ```
 
-    The required cluster template file can be found [here](https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/docs/benchmarks/infrastructure/cluster_pke.json)
+    The required cluster template file can be found [here](https://raw.githubusercontent.com/banzaicloud/koperator/master/docs/benchmarks/infrastructure/cluster_pke.json)
 
     > Please don't forget to fill out the template with the created ids.
 
@@ -63,7 +63,7 @@ banzai login
     banzai cluster create
     ```
 
-    The required cluster template file can be found [here](https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/docs/benchmarks/infrastructure/cluster_gke.json)
+    The required cluster template file can be found [here](https://raw.githubusercontent.com/banzaicloud/koperator/master/docs/benchmarks/infrastructure/cluster_gke.json)
 
     > Please don't forget to fill out the template with the created ids.
 
@@ -90,7 +90,7 @@ banzai login
     banzai cluster create
     ```
 
-    The required cluster template file can be found [here](https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/docs/benchmarks/infrastructure/cluster_eks.json)
+    The required cluster template file can be found [here](https://raw.githubusercontent.com/banzaicloud/koperator/master/docs/benchmarks/infrastructure/cluster_eks.json)
 
     > Please don't forget to fill out the template with the created ids.
 
@@ -137,7 +137,7 @@ banzai login
     helm install --name=kafka-operator banzaicloud-stable/kafka-operator
     ```
 
-1. Create a 3 broker Kafka Cluster using the [provided](https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/docs/benchmarks/infrastructure/kafka.yaml) yaml.
+1. Create a 3 broker Kafka Cluster using the [provided](https://raw.githubusercontent.com/banzaicloud/koperator/master/docs/benchmarks/infrastructure/kafka.yaml) yaml.
 
     This will install 3 brokers partitioned to three different zone with fast ssd.
 1. Create a client container inside the cluster
@@ -173,7 +173,7 @@ Monitoring environment automatically installed, find your cluster and Grafanas U
 
 ## Run the tests
 
-1. Run perf test against the cluster, by building the provided Docker [image](https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/docs/benchmarks/loadgens/Dockerfile)
+1. Run perf test against the cluster, by building the provided Docker [image](https://raw.githubusercontent.com/banzaicloud/koperator/master/docs/benchmarks/loadgens/Dockerfile)
 
     ```bash
     docker build -t yourname/perfload:0.1.0 /loadgens

--- a/docs/benchmarks/_index.md
+++ b/docs/benchmarks/_index.md
@@ -131,7 +131,7 @@ banzai login
     EOF
     ```
 
-1. Install the latest version of Banzai Cloud {{< kafka-operator >}}.
+1. Install the latest version of {{< kafka-operator >}}, the Operator for managing Apache Kafka on Kubernetes.
 
     ```bash
     helm install --name=kafka-operator banzaicloud-stable/kafka-operator

--- a/docs/benchmarks/_index.md
+++ b/docs/benchmarks/_index.md
@@ -131,7 +131,7 @@ banzai login
     EOF
     ```
 
-1. Install the latest version of Banzai Cloud Kafka Operator.
+1. Install the latest version of Banzai Cloud {{< kafka-operator >}}.
 
     ```bash
     helm install --name=kafka-operator banzaicloud-stable/kafka-operator

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -4,7 +4,7 @@ shorttitle: Supported versions
 weight: 770
 ---
 
-This page shows you the list of supported Kafka operator versions, and the versions of other components they are compatible with.
+This page shows you the list of supported {{< kafka-operator >}} versions, and the versions of other components they are compatible with.
 
 ## Compatibility matrix
 
@@ -14,7 +14,7 @@ This page shows you the list of supported Kafka operator versions, and the versi
 |v0.16.0|2.5.0+|0.15.0|2.5.37|1.9|[link](https://github.com/banzaicloud/kafka-operator/blob/v0.16.1/config/samples/simplekafkacluster.yaml)|+|
 |v0.17.0|2.5.0+|0.15.0|2.5.37|1.9|[link](https://github.com/banzaicloud/kafka-operator/blob/v0.17.0/config/samples/simplekafkacluster.yaml)|+|
 
-## Available Kafka operator images
+## Available {{< kafka-operator >}} images
 
 |Image|Go version|
 |-|-|

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -10,9 +10,9 @@ This page shows you the list of supported {{< kafka-operator >}} versions, and t
 
 |Operator Version|Apache Kafka Version|JMX Exporter Version|Cruise Control Version|Istio Operator Version|Example cluster CR|Maintained|
 |-------|------|----------------|-------|----|---|-|
-|v0.15.0|2.5.0+|0.14.0|2.5.28|1.8|[link](https://github.com/banzaicloud/kafka-operator/blob/v0.15.1/config/samples/simplekafkacluster.yaml)|+|
-|v0.16.0|2.5.0+|0.15.0|2.5.37|1.9|[link](https://github.com/banzaicloud/kafka-operator/blob/v0.16.1/config/samples/simplekafkacluster.yaml)|+|
-|v0.17.0|2.5.0+|0.15.0|2.5.37|1.9|[link](https://github.com/banzaicloud/kafka-operator/blob/v0.17.0/config/samples/simplekafkacluster.yaml)|+|
+|v0.15.0|2.5.0+|0.14.0|2.5.28|1.8|[link](https://github.com/banzaicloud/koperator/blob/v0.15.1/config/samples/simplekafkacluster.yaml)|+|
+|v0.16.0|2.5.0+|0.15.0|2.5.37|1.9|[link](https://github.com/banzaicloud/koperator/blob/v0.16.1/config/samples/simplekafkacluster.yaml)|+|
+|v0.17.0|2.5.0+|0.15.0|2.5.37|1.9|[link](https://github.com/banzaicloud/koperator/blob/v0.17.0/config/samples/simplekafkacluster.yaml)|+|
 
 ## Available {{< kafka-operator >}} images
 

--- a/docs/delete-kafka-operator.md
+++ b/docs/delete-kafka-operator.md
@@ -6,9 +6,9 @@ weight: 950
 
 In case you want to delete the {{< kafka-operator >}} from your cluster, note that because of dependencies between the various components, they must be deleted in specific order.
 
-{{< warning >}}It’s important to delete the kafka-operator deployment as the last step.
+{{< warning >}}It’s important to delete the {{< kafka-operator >}} deployment as the last step.
 {{< /warning >}}
 
 1. Delete the *KafkaCluster* custom resources that represent the Kafka cluster and Cruise Control.
-1. Wait until kafka-operator deletes all resources.  Note that KafkaCluster, KafkaTopic and KafkaUser custom resources are protected with kubernetes finalizers, so those won’t be actually deleted from Kubernetes until the kafka-operator removes those finalizers. After the kafka-operator has finished cleaning up everything, it removes the finalizers. In case you delete the kafka-operator deployment before it cleans up everything you need to remove the finalizers manually.
-1. Delete the kafka-operator deployment.
+1. Wait until {{< kafka-operator >}} deletes all resources.  Note that KafkaCluster, KafkaTopic and KafkaUser custom resources are protected with Kubernetes finalizers, so those won’t be actually deleted from Kubernetes until the {{< kafka-operator >}} removes those finalizers. After the {{< kafka-operator >}} has finished cleaning up everything, it removes the finalizers. In case you delete the {{< kafka-operator >}} deployment before it cleans up everything, you need to remove the finalizers manually.
+1. Delete the {{< kafka-operator >}} deployment.

--- a/docs/delete-kafka-operator.md
+++ b/docs/delete-kafka-operator.md
@@ -1,10 +1,10 @@
 ---
-title: Delete Kafka operator
+title: Delete the operator
 shorttitle: Delete operator
 weight: 950
 ---
 
-In case you want to delete the Kafka operator from your cluster, note that because of dependencies between the various components, they must be deleted in specific order.
+In case you want to delete the {{< kafka-operator >}} from your cluster, note that because of dependencies between the various components, they must be deleted in specific order.
 
 {{< warning >}}It’s important to delete the kafka-operator deployment as the last step.
 {{< /warning >}}

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -15,7 +15,7 @@ If you find this project useful here's how you can help:
 
 When you are opening a PR to {{< kafka-operator >}} the first time we will require you to sign a standard CLA.
 
-## How to run Kafka-operator in your cluster with your changes
+## How to run {{< kafka-operator >}} in your cluster with your changes
 
 The {{< kafka-operator >}} is built on the [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) project.
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -13,11 +13,11 @@ If you find this project useful here's how you can help:
 - Help new users with issues they may encounter
 - Support the development of this project and [star this repo](https://github.com/banzaicloud/kafka-operator/)!
 
-When you are opening a PR to Kafka operator the first time we will require you to sign a standard CLA.
+When you are opening a PR to {{< kafka-operator >}} the first time we will require you to sign a standard CLA.
 
 ## How to run Kafka-operator in your cluster with your changes
 
-The Kafka operator is built on the [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) project.
+The {{< kafka-operator >}} is built on the [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) project.
 
 To build the operator and run tests:
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -11,7 +11,7 @@ If you find this project useful here's how you can help:
 
 - Send a pull request with your new features and bug fixes
 - Help new users with issues they may encounter
-- Support the development of this project and [star this repo](https://github.com/banzaicloud/kafka-operator/)!
+- Support the development of this project and [star this repo](https://github.com/banzaicloud/koperator/)!
 
 When you are opening a PR to {{< kafka-operator >}} the first time we will require you to sign a standard CLA.
 

--- a/docs/external-listener/index.md
+++ b/docs/external-listener/index.md
@@ -4,7 +4,7 @@ shorttitle: External listeners
 weight: 700
 ---
 
-There are two methods to expose your Kafka cluster so that external client applications that run outside the Kubernetes cluster can access it:
+There are two methods to expose your Apache Kafka cluster so that external client applications that run outside the Kubernetes cluster can access it:
 
 - using [LoadBalancer](#loadbalancer) type services
 - using [NodePort](#nodeport) type services

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,7 +25,7 @@ Using StatefulSet we **lose:**
 - to remove a specific Broker from a cluster (StatefulSet always removes the most recently created Broker)
 - to use multiple, different Persistent Volumes for each Broker
 
-{{< kafka-operator >}} uses `simple` Pods, ConfigMaps, and PersistentVolumeClaims, instead of StatefulSet. Using these resources allows us to build an Operator which is better suited to managing Apache Kafka.
+{{< kafka-operator >}} uses `simple` Pods, ConfigMaps, and PersistentVolumeClaims, instead of StatefulSet. Using these resources allows us to build an Operator which is better suited to manage Apache Kafka.
 
 With the {{< kafka-operator >}} you can:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,9 +25,9 @@ Using StatefulSet we **lose:**
 - to remove a specific Broker from a cluster (StatefulSet always removes the most recently created Broker)
 - to use multiple, different Persistent Volumes for each Broker
 
-The Banzai Cloud {{< kafka-operator >}} uses `simple` Pods, ConfigMaps, and PersistentVolumeClaims, instead of StatefulSet. Using these resources allows us to build an Operator which is better suited to Kafka.
+{{< kafka-operator >}} uses `simple` Pods, ConfigMaps, and PersistentVolumeClaims, instead of StatefulSet. Using these resources allows us to build an Operator which is better suited to managing Apache Kafka.
 
-With the Banzai Cloud {{< kafka-operator >}} we can:
+With the {{< kafka-operator >}} you can:
 
 - modify the configuration of unique Brokers
 - remove specific Brokers from clusters
@@ -37,7 +37,7 @@ With the Banzai Cloud {{< kafka-operator >}} we can:
 
 ### Fine Grained Broker Config Support
 
-We needed to be able to react to events in a fine-grained way for each Broker - and not in the limited way StatefulSet does (which, for example, removes the most recently created Brokers). Some of the available solutions try to overcome these deficits by placing scripts inside the container to generate configs at runtime, whereas the Banzai Cloud {{< kafka-operator >}}'s configurations are deterministically placed in specific Configmaps.
+We needed to be able to react to events in a fine-grained way for each Broker - and not in the limited way StatefulSet does (which, for example, removes the most recently created Brokers). Some of the available solutions try to overcome these deficits by placing scripts inside the container to generate configs at runtime, whereas the {{< kafka-operator >}}'s configurations are deterministically placed in specific Configmaps.
 
 ### Graceful Kafka Cluster Scaling
 
@@ -45,7 +45,7 @@ Here at Banzai Cloud, we know how to operate Apache Kafka at scale (we are contr
 
 ### External Access via LoadBalancer
 
-The Banzai Cloud {{< kafka-operator >}} externalizes access to Apache Kafka using a dynamically (re)configured Envoy proxy. Using Envoy allows us to use **a single** LoadBalancer, so there's no need for a LoadBalancer for each Broker.
+The {{< kafka-operator >}} externalizes access to Apache Kafka using a dynamically (re)configured Envoy proxy. Using Envoy allows us to use **a single** LoadBalancer, so there's no need for a LoadBalancer for each Broker.
 
 ![Kafka External Access](../img/kafka-external.png)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -41,11 +41,11 @@ We needed to be able to react to events in a fine-grained way for each Broker - 
 
 ### Graceful Kafka Cluster Scaling
 
-Here at Banzai Cloud, we know how to operate Kafka at scale (we are contributors and have been operating Kafka on Kubernetes for years now). We believe, however, that LinkedIn has even more experience than we do. To scale Kafka clusters both up and down gracefully, we integrated LinkedIn's [Cruise-Control](https://github.com/linkedin/cruise-control) to do the hard work for us. We already have good defaults (i.e. plugins) that react to events, but we also allow our users to write their own.
+Here at Banzai Cloud, we know how to operate Apache Kafka at scale (we are contributors and have been operating Kafka on Kubernetes for years now). We believe, however, that LinkedIn has even more experience than we do. To scale Kafka clusters both up and down gracefully, we integrated LinkedIn's [Cruise-Control](https://github.com/linkedin/cruise-control) to do the hard work for us. We already have good defaults (i.e. plugins) that react to events, but we also allow our users to write their own.
 
 ### External Access via LoadBalancer
 
-The Banzai Cloud Kafka operator externalizes access to Kafka using a dynamically (re)configured Envoy proxy. Using Envoy allows us to use **a single** LoadBalancer, so there's no need for a LoadBalancer for each Broker.
+The Banzai Cloud Kafka operator externalizes access to Apache Kafka using a dynamically (re)configured Envoy proxy. Using Envoy allows us to use **a single** LoadBalancer, so there's no need for a LoadBalancer for each Broker.
 
 ![Kafka External Access](../img/kafka-external.png)
 
@@ -95,5 +95,5 @@ a dynamic reconfiguration.
 ### Seamless Istio mesh support
 
 - Operator allows to use ClusterIP services instead of Headless, which still works better in case of Service meshes.
-- To avoid too early kafka initialization, which might lead to unready sidecar container. The operator uses a small script to mitigate this behavior. All Kafka image can be used the only one requirement is an available **curl** command.
+- To avoid too early Kafka initialization, which might lead to unready sidecar container. The operator uses a small script to mitigate this behavior. All Kafka image can be used the only one requirement is an available **curl** command.
 - To access a Kafka cluster which runs inside the mesh. Operator supports creating Istio ingress gateways.

--- a/docs/features.md
+++ b/docs/features.md
@@ -95,5 +95,5 @@ a dynamic reconfiguration.
 ### Seamless Istio mesh support
 
 - Operator allows to use ClusterIP services instead of Headless, which still works better in case of Service meshes.
-- To avoid too early Kafka initialization, which might lead to unready sidecar container. The operator uses a small script to mitigate this behavior. All Kafka image can be used the only one requirement is an available **curl** command.
+- To avoid too early Kafka initialization, which might lead to unready sidecar container. The operator uses a small script to mitigate this behaviour. Any Kafka image can be used with the only requirement of an available **curl** command.
 - To access a Kafka cluster which runs inside the mesh. Operator supports creating Istio ingress gateways.

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,9 +25,9 @@ Using StatefulSet we **lose:**
 - to remove a specific Broker from a cluster (StatefulSet always removes the most recently created Broker)
 - to use multiple, different Persistent Volumes for each Broker
 
-The Banzai Cloud Kafka Operator uses `simple` Pods, ConfigMaps, and PersistentVolumeClaims, instead of StatefulSet. Using these resources allows us to build an Operator which is better suited to Kafka.
+The Banzai Cloud {{< kafka-operator >}} uses `simple` Pods, ConfigMaps, and PersistentVolumeClaims, instead of StatefulSet. Using these resources allows us to build an Operator which is better suited to Kafka.
 
-With the Banzai Cloud Kafka operator we can:
+With the Banzai Cloud {{< kafka-operator >}} we can:
 
 - modify the configuration of unique Brokers
 - remove specific Brokers from clusters
@@ -37,7 +37,7 @@ With the Banzai Cloud Kafka operator we can:
 
 ### Fine Grained Broker Config Support
 
-We needed to be able to react to events in a fine-grained way for each Broker - and not in the limited way StatefulSet does (which, for example, removes the most recently created Brokers). Some of the available solutions try to overcome these deficits by placing scripts inside the container to generate configs at runtime, whereas the Banzai Cloud Kafka operator's configurations are deterministically placed in specific Configmaps.
+We needed to be able to react to events in a fine-grained way for each Broker - and not in the limited way StatefulSet does (which, for example, removes the most recently created Brokers). Some of the available solutions try to overcome these deficits by placing scripts inside the container to generate configs at runtime, whereas the Banzai Cloud {{< kafka-operator >}}'s configurations are deterministically placed in specific Configmaps.
 
 ### Graceful Kafka Cluster Scaling
 
@@ -45,7 +45,7 @@ Here at Banzai Cloud, we know how to operate Apache Kafka at scale (we are contr
 
 ### External Access via LoadBalancer
 
-The Banzai Cloud Kafka operator externalizes access to Apache Kafka using a dynamically (re)configured Envoy proxy. Using Envoy allows us to use **a single** LoadBalancer, so there's no need for a LoadBalancer for each Broker.
+The Banzai Cloud {{< kafka-operator >}} externalizes access to Apache Kafka using a dynamically (re)configured Envoy proxy. Using Envoy allows us to use **a single** LoadBalancer, so there's no need for a LoadBalancer for each Broker.
 
 ![Kafka External Access](../img/kafka-external.png)
 
@@ -59,11 +59,11 @@ The Pipeline platform is capable of automating this process, as well.
 
 ### Monitoring via Prometheus
 
-The Kafka operator exposes Cruise-Control and Kafka JMX metrics to Prometheus.
+The {{< kafka-operator >}} exposes Cruise-Control and Kafka JMX metrics to Prometheus.
 
 ### Reacting on Alerts
 
-The Kafka Operator acts as a **Prometheus Alert Manager**. It receives alerts defined in Prometheus, and creates actions based on Prometheus alert annotations.
+The {{< kafka-operator >}} acts as a **Prometheus Alert Manager**. It receives alerts defined in Prometheus, and creates actions based on Prometheus alert annotations.
 
 Currently, there are three default actions (which can be extended):
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,7 +11,7 @@ All Kafka on Kubernetes operators use [StatefulSet](https://kubernetes.io/docs/c
 
 >StatefulSet manages the deployment and scaling of a set of Pods, and provide guarantees about their ordering and uniqueness. Like a Deployment, a StatefulSet manages Pods that are based on an identical container spec. Unlike a Deployment, a StatefulSet maintains sticky identities for each of its Pods. These pods are created from the same spec, but are not interchangeable: each has a persistent identifier that is maintained across any rescheduling.
 
-How does this looks from the perspective of Apache Kafka?
+How does this look from the perspective of Apache Kafka?
 
 With StatefulSet we get:
 

--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -156,12 +156,12 @@ Install the [Prometheus operator](https://github.com/prometheus-operator/prometh
 
 ### Install the {{< kafka-operator >}} with Helm {#kafka-operator-helm}
 
-You can deploy the {{< kafka-operator >}} using a [Helm chart](https://github.com/banzaicloud/kafka-operator/tree/master/charts). Complete the following steps.
+You can deploy the {{< kafka-operator >}} using a [Helm chart](https://github.com/banzaicloud/koperator/tree/master/charts). Complete the following steps.
 
 1. Install the kafka-operator CustomResourceDefinition resources (adjust the version number to the {{< kafka-operator >}} release you want to install). This is performed in a separate step to allow you to easily uninstall and reinstall kafka-operator without deleting your installed custom resources.
 
     ```bash
-    kubectl create --validate=false -f https://github.com/banzaicloud/kafka-operator/releases/download/v0.15.1/kafka-operator.crds.yaml
+    kubectl create --validate=false -f https://github.com/banzaicloud/koperator/releases/download/v0.15.1/kafka-operator.crds.yaml
     ```
 
 1. Add the Banzai Cloud repository to Helm.
@@ -177,7 +177,7 @@ You can deploy the {{< kafka-operator >}} using a [Helm chart](https://github.co
     helm install kafka-operator --namespace=kafka --create-namespace banzaicloud-stable/kafka-operator
     ```
 
-1. Create the Kafka cluster using the KafkaCluster custom resource. You can find various examples for the custom resource in the [{{< kafka-operator >}} repository](https://github.com/banzaicloud/kafka-operator/tree/master/config/samples).
+1. Create the Kafka cluster using the KafkaCluster custom resource. You can find various examples for the custom resource in the [{{< kafka-operator >}} repository](https://github.com/banzaicloud/koperator/tree/master/config/samples).
 
     {{< include-headless "warning-listener-protocol.md" "supertubes/kafka-operator" >}}
 

--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -158,7 +158,7 @@ Install the [Prometheus operator](https://github.com/prometheus-operator/prometh
 
 You can deploy the {{< kafka-operator >}} using a [Helm chart](https://github.com/banzaicloud/koperator/tree/master/charts). Complete the following steps.
 
-1. Install the kafka-operator CustomResourceDefinition resources (adjust the version number to the {{< kafka-operator >}} release you want to install). This is performed in a separate step to allow you to easily uninstall and reinstall kafka-operator without deleting your installed custom resources.
+1. Install the {{< kafka-operator >}} CustomResourceDefinition resources (adjust the version number to the {{< kafka-operator >}} release you want to install). This is performed in a separate step to allow you to uninstall and reinstall {{< kafka-operator >}} without deleting your installed custom resources.
 
     ```bash
     kubectl create --validate=false -f https://github.com/banzaicloud/koperator/releases/download/v0.15.1/kafka-operator.crds.yaml

--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -1,5 +1,5 @@
 ---
-title: Install the Kafka operator
+title: Install the operator
 shorttitle: Install
 weight: 10
 ---
@@ -14,11 +14,11 @@ The operator installs the 2.7.0 version of Apache Kafka, and can run on Minikube
 
 - A Kubernetes cluster (minimum 6 vCPU and 10 GB RAM). You can create one using the [Banzai Cloud Pipeline platform](/products/pipeline/), or any other tool of your choice.
 
-> We believe in the `separation of concerns` principle, thus the Kafka operator does not install nor manage Zookeeper or cert-manager. If you would like to have a fully automated and managed experience of Apache Kafka on Kubernetes, try [Banzai Cloud Supertubes](/products/supertubes/).
+> We believe in the `separation of concerns` principle, thus the {{< kafka-operator >}} does not install nor manage Zookeeper or cert-manager. If you would like to have a fully automated and managed experience of Apache Kafka on Kubernetes, try [Banzai Cloud Supertubes](/products/supertubes/).
 
-## Install Kafka operator and all requirements using Supertubes
+## Install {{< kafka-operator >}} and all requirements using Supertubes
 
-This method uses a command-line tool of the commercial [Banzai Cloud Supertubes](/products/supertubes/) product to install the Kafka operator and its prerequisites. If you'd prefer to install these components manually, see [Install Kafka operator and the requirements independently](#manual-install).
+This method uses a command-line tool of the commercial [Banzai Cloud Supertubes](/products/supertubes/) product to install the {{< kafka-operator >}} and its prerequisites. If you'd prefer to install these components manually, see [Install {{< kafka-operator >}} and the requirements independently](#manual-install).
 
 1. [Register for an evaluation version of Supertubes](/products/try-supertubes/).
 
@@ -32,16 +32,16 @@ This method uses a command-line tool of the commercial [Banzai Cloud Supertubes]
     supertubes install -a
     ```
 
-## Install Kafka operator and the requirements independently {#manual-install}
+## Install {{< kafka-operator >}} and the requirements independently {#manual-install}
 
 ### Install cert-manager {#install-cert-manager}
 
-The Kafka operator uses [cert-manager](https://cert-manager.io) for issuing certificates to clients and brokers. Deploy and configure cert-manager if you haven't already done so.
+The {{< kafka-operator >}} uses [cert-manager](https://cert-manager.io) for issuing certificates to clients and brokers. Deploy and configure cert-manager if you haven't already done so.
 
 > Note:
 >
-> - Kafka operator 0.8.x and newer supports cert-manager 1.3.x
-> - Kafka operator 0.7.x supports cert-manager 0.10.x
+> - {{< kafka-operator >}} 0.8.x and newer supports cert-manager 1.3.x
+> - {{< kafka-operator >}} 0.7.x supports cert-manager 0.10.x
 
 Install cert-manager and the CustomResourceDefinitions using one of the following methods:
 
@@ -154,11 +154,11 @@ Install the [Prometheus operator](https://github.com/prometheus-operator/prometh
     --set prometheus.enabled=false
     ```
 
-### Install the Kafka operator with Helm {#kafka-operator-helm}
+### Install the {{< kafka-operator >}} with Helm {#kafka-operator-helm}
 
-You can deploy the Kafka operator using a [Helm chart](https://github.com/banzaicloud/kafka-operator/tree/master/charts). Complete the following steps.
+You can deploy the {{< kafka-operator >}} using a [Helm chart](https://github.com/banzaicloud/kafka-operator/tree/master/charts). Complete the following steps.
 
-1. Install the kafka-operator CustomResourceDefinition resources (adjust the version number to the Kafka operator release you want to install). This is performed in a separate step to allow you to easily uninstall and reinstall kafka-operator without deleting your installed custom resources.
+1. Install the kafka-operator CustomResourceDefinition resources (adjust the version number to the {{< kafka-operator >}} release you want to install). This is performed in a separate step to allow you to easily uninstall and reinstall kafka-operator without deleting your installed custom resources.
 
     ```bash
     kubectl create --validate=false -f https://github.com/banzaicloud/kafka-operator/releases/download/v0.15.1/kafka-operator.crds.yaml
@@ -171,13 +171,13 @@ You can deploy the Kafka operator using a [Helm chart](https://github.com/banzai
     helm repo update
     ```
 
-1. Install the Kafka operator into the *kafka* namespace:
+1. Install the {{< kafka-operator >}} into the *kafka* namespace:
 
     ```bash
     helm install kafka-operator --namespace=kafka --create-namespace banzaicloud-stable/kafka-operator
     ```
 
-1. Create the Kafka cluster using the KafkaCluster custom resource. You can find various examples for the custom resource in the [Kafka operator repository](https://github.com/banzaicloud/kafka-operator/tree/master/config/samples).
+1. Create the Kafka cluster using the KafkaCluster custom resource. You can find various examples for the custom resource in the [{{< kafka-operator >}} repository](https://github.com/banzaicloud/kafka-operator/tree/master/config/samples).
 
     {{< include-headless "warning-listener-protocol.md" "supertubes/kafka-operator" >}}
 
@@ -193,7 +193,7 @@ You can deploy the Kafka operator using a [Helm chart](https://github.com/banzai
         kubectl create -n kafka -f https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/config/samples/simplekafkacluster_ssl.yaml
         ```
 
-1. If you have installed the Prometheus operator, create the ServiceMonitors. Prometheus will be installed and configured properly for the Kafka operator.
+1. If you have installed the Prometheus operator, create the ServiceMonitors. Prometheus will be installed and configured properly for the {{< kafka-operator >}}.
 
     ```bash
     kubectl create -n kafka -f https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/config/samples/kafkacluster-prometheus.yaml

--- a/docs/install-kafka-operator.md
+++ b/docs/install-kafka-operator.md
@@ -184,19 +184,19 @@ You can deploy the {{< kafka-operator >}} using a [Helm chart](https://github.co
     - To create a sample Kafka cluster that allows unencrypted client connections, run the following command:
 
         ```bash
-        kubectl create -n kafka -f https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/config/samples/simplekafkacluster.yaml
+        kubectl create -n kafka -f https://raw.githubusercontent.com/banzaicloud/koperator/master/config/samples/simplekafkacluster.yaml
         ```
 
     - To create a sample Kafka cluster that allows TLS-encrypted client connections, run the following command. For details on the configuration parameters related to SSL, see {{% xref "/docs/supertubes/kafka-operator/ssl.md#enable-ssl" %}}.
 
         ```bash
-        kubectl create -n kafka -f https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/config/samples/simplekafkacluster_ssl.yaml
+        kubectl create -n kafka -f https://raw.githubusercontent.com/banzaicloud/koperator/master/config/samples/simplekafkacluster_ssl.yaml
         ```
 
 1. If you have installed the Prometheus operator, create the ServiceMonitors. Prometheus will be installed and configured properly for the {{< kafka-operator >}}.
 
     ```bash
-    kubectl create -n kafka -f https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/config/samples/kafkacluster-prometheus.yaml
+    kubectl create -n kafka -f https://raw.githubusercontent.com/banzaicloud/koperator/master/config/samples/kafkacluster-prometheus.yaml
     ```
 
 1. Verify that the Kafka cluster has been created.

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,5 +1,5 @@
 ---
-title: License of Kafka Operator
+title: License of Koperator
 weight: 10000
 ---
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,5 +1,5 @@
 ---
-title: License of Kafka operator
+title: License of Kafka Operator
 weight: 10000
 ---
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,12 +1,12 @@
 ---
-title: Monitoring Kafka on Kubernetes
+title: Monitoring Apache Kafka on Kubernetes
 shorttitle: Monitoring
 weight: 600
 ---
 
 
 
-This documentation shows you how to enable custom monitoring on a Kafka cluster installed using the [Kafka operator](/products/kafka-operator/).
+This documentation shows you how to enable custom monitoring on an Apache Kafka cluster installed using the [Kafka operator](/products/kafka-operator/).
 
 ## Using Helm for Prometheus
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -6,11 +6,11 @@ weight: 600
 
 
 
-This documentation shows you how to enable custom monitoring on an Apache Kafka cluster installed using the [Kafka operator](/products/kafka-operator/).
+This documentation shows you how to enable custom monitoring on an Apache Kafka cluster installed using the [{{< kafka-operator >}}](/products/kafka-operator/).
 
 ## Using Helm for Prometheus
 
-By default, the Kafka Operator does not set annotations on the broker pods. To set annotations on the broker pods, specify them in the KafkaCluster CR. Also, you must open port 9020 on brokers and in CruiseControl to enable scraping. For example:
+By default, the {{< kafka-operator >}} does not set annotations on the broker pods. To set annotations on the broker pods, specify them in the KafkaCluster CR. Also, you must open port 9020 on brokers and in CruiseControl to enable scraping. For example:
 
 ```yaml
 brokerConfigGroups:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -58,7 +58,7 @@ Prometheus must be configured to recognize these annotations. The following exam
       target_label: __address__
 ```
 
-If you are using the provided [CR](https://github.com/banzaicloud/kafka-operator/blob/master/config/samples/banzaicloud_v1beta1_kafkacluster.yaml), the operator installs the official [jmx exporter](https://github.com/prometheus/jmx_exporter) for Prometheus.
+If you are using the provided [CR](https://github.com/banzaicloud/koperator/blob/master/config/samples/banzaicloud_v1beta1_kafkacluster.yaml), the operator installs the official [jmx exporter](https://github.com/prometheus/jmx_exporter) for Prometheus.
 
 To change this behavior, modify the following lines at the end of the CR.
 

--- a/docs/rackawareness/index.md
+++ b/docs/rackawareness/index.md
@@ -43,7 +43,7 @@ Note that depending on your use case, you might need additional configuration on
 
 ## Under the hood
 
-As mentioned earlier, `broker.rack` is a read-only broker config, so is set whenever the broker starts or restarts. The Banzai Cloud [{{< kafka-operator >}}](https://github.com/banzaicloud/koperator) holds all its configs within a ConfigMap in each broker.
+As mentioned earlier, `broker.rack` is a read-only broker config, so is set whenever the broker starts or restarts. The [{{< kafka-operator >}}](https://github.com/banzaicloud/koperator) holds all its configs within a ConfigMap in each broker.
 Getting label values from nodes and using them to generate a ConfigMap is relatively easy, but to determine where the exact broker/pod is scheduled, the operator has to wait until the pod is *actually* scheduled to a node. Luckily, Kubernetes schedules pods even when a given ConfigMap is unavailable. However, the corresponding pod will remain in a pending state as long as the ConfigMap is not available to mount. The operator makes use of this pending state to gather all the necessary node labels and initialize a ConfigMap with the fetched data. To take advantage of this, we introduced a status field called `RackAwarenessState` in our CRD. The operator populates this status field with two values, `WaitingForRackAwareness` and `Configured`.
 
 ![Rack Awareness](/img/blog/kafka-rack-awareness/kafkarack.gif)

--- a/docs/rackawareness/index.md
+++ b/docs/rackawareness/index.md
@@ -6,11 +6,11 @@ weight: 750
 
 Kafka automatically replicates partitions across brokers, so if a broker fails, the data is safely preserved on another. Kafka's rack awareness feature spreads replicas of the same partition across different **failure groups** (racks or availability zones). This extends the guarantees Kafka provides for broker-failure to cover rack and availability zone (AZ) failures, limiting the risk of data loss should all the brokers in the same ack or AZ fail at once.
 
-> Note: All brokers deployed by the Kafka operator must belong to the same Kubernetes cluster. If you want to spread your brokers across multiple Kubernetes clusters, as in a hybrid-cloud or multi-clouds environment (or just to add geo-redundancy to your setup), consider using our commercial [Supertubes](/products/supertubes/) solution.
+> Note: All brokers deployed by the {{< kafka-operator >}} must belong to the same Kubernetes cluster. If you want to spread your brokers across multiple Kubernetes clusters, as in a hybrid-cloud or multi-clouds environment (or just to add geo-redundancy to your setup), consider using our commercial [Supertubes](/products/supertubes/) solution.
 
-Since rack awareness is so vitally important, especially in multi-region and hybrid-cloud environments, the [Kafka operator](https://github.com/banzaicloud/kafka-operator) provides an automated solution for it, and allows fine-grained broker rack configuration based on pod affinities and anti-affinities. (To learn more about affinities and anti-affinities, see [Taints and tolerations, pod and node affinities demystified]({{< blogref "k8s-taints-tolerations-affinities.md" >}}).)
+Since rack awareness is so vitally important, especially in multi-region and hybrid-cloud environments, the [{{< kafka-operator >}}](https://github.com/banzaicloud/kafka-operator) provides an automated solution for it, and allows fine-grained broker rack configuration based on pod affinities and anti-affinities. (To learn more about affinities and anti-affinities, see [Taints and tolerations, pod and node affinities demystified]({{< blogref "k8s-taints-tolerations-affinities.md" >}}).)
 
-When [well-known Kubernetes labels](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/) are available (for example, AZ, node labels, and so on), the Kafka operator attempts to improve broker resilience by default.
+When [well-known Kubernetes labels](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/) are available (for example, AZ, node labels, and so on), the {{< kafka-operator >}} attempts to improve broker resilience by default.
 
 ![Rack Awareness](kafkarack.png)
 
@@ -43,7 +43,7 @@ Note that depending on your use case, you might need additional configuration on
 
 ## Under the hood
 
-As mentioned earlier, `broker.rack` is a read-only broker config, so is set whenever the broker starts or restarts. The Banzai Cloud [Kafka operator](https://github.com/banzaicloud/kafka-operator) holds all its configs within a ConfigMap in each broker.
+As mentioned earlier, `broker.rack` is a read-only broker config, so is set whenever the broker starts or restarts. The Banzai Cloud [{{< kafka-operator >}}](https://github.com/banzaicloud/kafka-operator) holds all its configs within a ConfigMap in each broker.
 Getting label values from nodes and using them to generate a ConfigMap is relatively easy, but to determine where the exact broker/pod is scheduled, the operator has to wait until the pod is *actually* scheduled to a node. Luckily, Kubernetes schedules pods even when a given ConfigMap is unavailable. However, the corresponding pod will remain in a pending state as long as the ConfigMap is not available to mount. The operator makes use of this pending state to gather all the necessary node labels and initialize a ConfigMap with the fetched data. To take advantage of this, we introduced a status field called `RackAwarenessState` in our CRD. The operator populates this status field with two values, `WaitingForRackAwareness` and `Configured`.
 
 ![Rack Awareness](/img/blog/kafka-rack-awareness/kafkarack.gif)

--- a/docs/rackawareness/index.md
+++ b/docs/rackawareness/index.md
@@ -8,7 +8,7 @@ Kafka automatically replicates partitions across brokers, so if a broker fails, 
 
 > Note: All brokers deployed by the {{< kafka-operator >}} must belong to the same Kubernetes cluster. If you want to spread your brokers across multiple Kubernetes clusters, as in a hybrid-cloud or multi-clouds environment (or just to add geo-redundancy to your setup), consider using our commercial [Supertubes](/products/supertubes/) solution.
 
-Since rack awareness is so vitally important, especially in multi-region and hybrid-cloud environments, the [{{< kafka-operator >}}](https://github.com/banzaicloud/kafka-operator) provides an automated solution for it, and allows fine-grained broker rack configuration based on pod affinities and anti-affinities. (To learn more about affinities and anti-affinities, see [Taints and tolerations, pod and node affinities demystified]({{< blogref "k8s-taints-tolerations-affinities.md" >}}).)
+Since rack awareness is so vitally important, especially in multi-region and hybrid-cloud environments, the [{{< kafka-operator >}}](https://github.com/banzaicloud/koperator) provides an automated solution for it, and allows fine-grained broker rack configuration based on pod affinities and anti-affinities. (To learn more about affinities and anti-affinities, see [Taints and tolerations, pod and node affinities demystified]({{< blogref "k8s-taints-tolerations-affinities.md" >}}).)
 
 When [well-known Kubernetes labels](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/) are available (for example, AZ, node labels, and so on), the {{< kafka-operator >}} attempts to improve broker resilience by default.
 
@@ -43,7 +43,7 @@ Note that depending on your use case, you might need additional configuration on
 
 ## Under the hood
 
-As mentioned earlier, `broker.rack` is a read-only broker config, so is set whenever the broker starts or restarts. The Banzai Cloud [{{< kafka-operator >}}](https://github.com/banzaicloud/kafka-operator) holds all its configs within a ConfigMap in each broker.
+As mentioned earlier, `broker.rack` is a read-only broker config, so is set whenever the broker starts or restarts. The Banzai Cloud [{{< kafka-operator >}}](https://github.com/banzaicloud/koperator) holds all its configs within a ConfigMap in each broker.
 Getting label values from nodes and using them to generate a ConfigMap is relatively easy, but to determine where the exact broker/pod is scheduled, the operator has to wait until the pod is *actually* scheduled to a node. Luckily, Kubernetes schedules pods even when a given ConfigMap is unavailable. However, the corresponding pod will remain in a pending state as long as the ConfigMap is not available to mount. The operator makes use of this pending state to gather all the necessary node labels and initialize a ConfigMap with the fetched data. To take advantage of this, we introduced a status field called `RackAwarenessState` in our CRD. The operator populates this status field with two values, `WaitingForRackAwareness` and `Configured`.
 
 ![Rack Awareness](/img/blog/kafka-rack-awareness/kafkarack.gif)

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -13,23 +13,23 @@ As highlighted in the [features section](../features/), we removed the reliance 
 
 We've encountered many situations in which the horizontal scaling of a cluster is impossible. When **only one Broker is throttling** and needs more CPU or requires additional disks (because it handles the most partitions), a StatefulSet-based solution is useless, since it does not distinguishes between replicas' specifications. The handling of such a case requires *unique* Broker configurations. If we need to add a new disk to a unique Broker, we waste a lot of disk space (and money) with a StatefulSet-based solution, since it can't add a disk to a specific Broker, the StatefulSet adds one to each replica.
 
-With the [Banzai Cloud Kafka operator](https://github.com/banzaicloud/kafka-operator), adding a new disk to any Broker is as easy as changing a CR configuration. Similarly, any Broker-specific configuration can be done on a Broker by Broker basis.
+With the [Banzai Cloud {{< kafka-operator >}}](https://github.com/banzaicloud/kafka-operator), adding a new disk to any Broker is as easy as changing a CR configuration. Similarly, any Broker-specific configuration can be done on a Broker by Broker basis.
 
 ## An unhandled error with Broker #1 in a three Broker cluster
 
 In the event of an error with Broker #1, we want to handle it without disrupting the other Brokers. Maybe we would like to temporarily remove this Broker from the cluster, and fix its state, reconciling the node that serves the node, or maybe reconfigure the Broker using a new configuration. Again, when using StatefulSet, we lose the ability to remove specific Brokers from the cluster. StatefulSet only supports a field name replica that determines how many replicas an application should use. If there's a downscale/removal, this number can be lowered, however, this means that Kubernetes will remove the most recently added Pod (Broker #3) from the cluster - which, in this case, happens to suit our purposes quite well.
 
-To remove the #1 Broker from the cluster, we need to lower the number of brokers in the cluster from three to one. This will cause a state in which only one Broker is live, while we kill the brokers that handle traffic. The Banzai Cloud Kafka operator supports removing specific brokers without disrupting traffic in the cluster.
+To remove the #1 Broker from the cluster, we need to lower the number of brokers in the cluster from three to one. This will cause a state in which only one Broker is live, while we kill the brokers that handle traffic. The Banzai Cloud {{< kafka-operator >}} supports removing specific brokers without disrupting traffic in the cluster.
 
 ## Fine grained Broker config support
 
 Apache Kafka is a stateful application, where Brokers create/form a cluster with other Brokers. Every Broker is uniquely configurable (we support heterogenous environments, in which no nodes are the same, act the same or have the same specifications - from the infrastructure up through the Brokers' Envoy configuration). Kafka has lots of Broker configs, which can be used to fine tune specific brokers, and we did not want to limit these to ALL Brokers in a StatefulSet. We support unique Broker configs.
 
-*In each of the three scenarios lister above, we decided to not use StatefulSet in our Kafka Operator, relying, instead, on Pods, PVCs and ConfigMaps. We believe StatefulSet is very convenient starting point, as it handles roughly 80% of scenarios but introduces huge limitations when running Kafka on Kubernetes in production.*
+*In each of the three scenarios lister above, we decided to not use StatefulSet in our {{< kafka-operator >}}, relying, instead, on Pods, PVCs and ConfigMaps. We believe StatefulSet is very convenient starting point, as it handles roughly 80% of scenarios but introduces huge limitations when running Kafka on Kubernetes in production.*
 
 ## Monitoring based control
 
-Use of monitoring is essential for any application, and all relevant information about Kafka should be published to a monitoring solution. When using Kubernetes, the de facto solution is Prometheus, which supports configuring alerts based on previously consumed metrics. We wanted to build a standards-based solution (Prometheus and Alert Manager) that could handle and react to alerts automatically, so human operators wouldn't have to. The Banzai Cloud Kafka operator supports alert-based Kafka cluster management.
+Use of monitoring is essential for any application, and all relevant information about Kafka should be published to a monitoring solution. When using Kubernetes, the de facto solution is Prometheus, which supports configuring alerts based on previously consumed metrics. We wanted to build a standards-based solution (Prometheus and Alert Manager) that could handle and react to alerts automatically, so human operators wouldn't have to. The Banzai Cloud {{< kafka-operator >}} supports alert-based Kafka cluster management.
 
 ## LinkedIn's Cruise Control
 

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -13,7 +13,7 @@ As highlighted in the [features section](../features/), we removed the reliance 
 
 We've encountered many situations in which the horizontal scaling of a cluster is impossible. When **only one Broker is throttling** and needs more CPU or requires additional disks (because it handles the most partitions), a StatefulSet-based solution is useless, since it does not distinguish between replicas' specifications. The handling of such a case requires *unique* Broker configurations. If we need to add a new disk to a unique Broker, we waste a lot of disk space (and money) with a StatefulSet-based solution, since it can't add a disk to a specific Broker, the StatefulSet adds one to each replica.
 
-With the [{{< kafka-operator >}}](https://github.com/banzaicloud/kafka-operator), adding a new disk to any Broker is as easy as changing a CR configuration. Similarly, any Broker-specific configuration can be done on a Broker by Broker basis.
+With the [{{< kafka-operator >}}](https://github.com/banzaicloud/koperator), adding a new disk to any Broker is as easy as changing a CR configuration. Similarly, any Broker-specific configuration can be done on a Broker by Broker basis.
 
 ## An unhandled error with Broker #1 in a three Broker cluster
 

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -11,7 +11,7 @@ As highlighted in the [features section](../features/), we removed the reliance 
 
 ## Vertical capacity scaling
 
-We've encountered many situations in which the horizontal scaling of a cluster is impossible. When **only one Broker is throttling** and needs more CPU or requires additional disks (because it handles the most partitions), a StatefulSet-based solution is useless, since it does not distinguishes between replicas' specifications. The handling of such a case requires *unique* Broker configurations. If we need to add a new disk to a unique Broker, we waste a lot of disk space (and money) with a StatefulSet-based solution, since it can't add a disk to a specific Broker, the StatefulSet adds one to each replica.
+We've encountered many situations in which the horizontal scaling of a cluster is impossible. When **only one Broker is throttling** and needs more CPU or requires additional disks (because it handles the most partitions), a StatefulSet-based solution is useless, since it does not distinguish between replicas' specifications. The handling of such a case requires *unique* Broker configurations. If we need to add a new disk to a unique Broker, we waste a lot of disk space (and money) with a StatefulSet-based solution, since it can't add a disk to a specific Broker, the StatefulSet adds one to each replica.
 
 With the [Banzai Cloud {{< kafka-operator >}}](https://github.com/banzaicloud/kafka-operator), adding a new disk to any Broker is as easy as changing a CR configuration. Similarly, any Broker-specific configuration can be done on a Broker by Broker basis.
 

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -13,13 +13,13 @@ As highlighted in the [features section](../features/), we removed the reliance 
 
 We've encountered many situations in which the horizontal scaling of a cluster is impossible. When **only one Broker is throttling** and needs more CPU or requires additional disks (because it handles the most partitions), a StatefulSet-based solution is useless, since it does not distinguish between replicas' specifications. The handling of such a case requires *unique* Broker configurations. If we need to add a new disk to a unique Broker, we waste a lot of disk space (and money) with a StatefulSet-based solution, since it can't add a disk to a specific Broker, the StatefulSet adds one to each replica.
 
-With the [Banzai Cloud {{< kafka-operator >}}](https://github.com/banzaicloud/kafka-operator), adding a new disk to any Broker is as easy as changing a CR configuration. Similarly, any Broker-specific configuration can be done on a Broker by Broker basis.
+With the [{{< kafka-operator >}}](https://github.com/banzaicloud/kafka-operator), adding a new disk to any Broker is as easy as changing a CR configuration. Similarly, any Broker-specific configuration can be done on a Broker by Broker basis.
 
 ## An unhandled error with Broker #1 in a three Broker cluster
 
 In the event of an error with Broker #1, we want to handle it without disrupting the other Brokers. Maybe we would like to temporarily remove this Broker from the cluster, and fix its state, reconciling the node that serves the node, or maybe reconfigure the Broker using a new configuration. Again, when using StatefulSet, we lose the ability to remove specific Brokers from the cluster. StatefulSet only supports a field name replica that determines how many replicas an application should use. If there's a downscale/removal, this number can be lowered, however, this means that Kubernetes will remove the most recently added Pod (Broker #3) from the cluster - which, in this case, happens to suit our purposes quite well.
 
-To remove the #1 Broker from the cluster, we need to lower the number of brokers in the cluster from three to one. This will cause a state in which only one Broker is live, while we kill the brokers that handle traffic. The Banzai Cloud {{< kafka-operator >}} supports removing specific brokers without disrupting traffic in the cluster.
+To remove the #1 Broker from the cluster, we need to lower the number of brokers in the cluster from three to one. This will cause a state in which only one Broker is live, while we kill the brokers that handle traffic. The {{< kafka-operator >}} supports removing specific brokers without disrupting traffic in the cluster.
 
 ## Fine grained Broker config support
 
@@ -29,7 +29,7 @@ Apache Kafka is a stateful application, where Brokers create/form a cluster with
 
 ## Monitoring based control
 
-Use of monitoring is essential for any application, and all relevant information about Kafka should be published to a monitoring solution. When using Kubernetes, the de facto solution is Prometheus, which supports configuring alerts based on previously consumed metrics. We wanted to build a standards-based solution (Prometheus and Alert Manager) that could handle and react to alerts automatically, so human operators wouldn't have to. The Banzai Cloud {{< kafka-operator >}} supports alert-based Kafka cluster management.
+Use of monitoring is essential for any application, and all relevant information about Kafka should be published to a monitoring solution. When using Kubernetes, the de facto solution is Prometheus, which supports configuring alerts based on previously consumed metrics. We wanted to build a standards-based solution (Prometheus and Alert Manager) that could handle and react to alerts automatically, so human operators wouldn't have to. The {{< kafka-operator >}} supports alert-based Kafka cluster management.
 
 ## LinkedIn's Cruise Control
 

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -4,11 +4,11 @@ shorttitle: SSL
 weight: 300
 ---
 
-The Kafka operator makes securing your Kafka cluster with SSL simple.
+The Kafka operator makes securing your Apache Kafka cluster with SSL simple.
 
-## Enable SSL encryption in Kafka {#enable-ssl}
+## Enable SSL encryption in Apache Kafka {#enable-ssl}
 
-To create a Kafka cluster with SSL encryption enabled, you must enable SSL encryption and configure the secrets in the **listenersConfig** section of your **KafkaCluster** Custom Resource. You can provide your own certificates, or instruct the operator to create them for you from your cluster configuration.
+To create an Apache Kafka cluster with SSL encryption enabled, you must enable SSL encryption and configure the secrets in the **listenersConfig** section of your **KafkaCluster** Custom Resource. You can provide your own certificates, or instruct the operator to create them for you from your cluster configuration.
 
 {{< include-headless "warning-listener-protocol.md" "supertubes/kafka-operator" >}}
 
@@ -32,10 +32,10 @@ If `sslSecrets.create` is `false`, the operator will look for the secret at `ssl
 > Note: The Kafka operator provides only basic ACL support. For a more complete and robust solution, consider using the [Supertubes](/products/supertubes/) product.
 > {{< include-headless "doc/kafka-operator-supertubes-intro.md" >}}
 
-If you choose not to enable ACLs for your kafka cluster, you may still use the `KafkaUser` resource to create new certificates for your applications.
+If you choose not to enable ACLs for your Apache Kafka cluster, you may still use the `KafkaUser` resource to create new certificates for your applications.
 You can leave the `topicGrants` out as they will not have any effect.
 
-1. To enable ACL support for your kafka cluster, pass the following configurations along with your `brokerConfig`:
+1. To enable ACL support for your Kafka cluster, pass the following configurations along with your `brokerConfig`:
 
     ```yaml
     authorizer.class.name=kafka.security.authorizer.AclAuthorizer

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -143,7 +143,7 @@ An easy way to get up and running quickly with `vault` on your Kubernetes cluste
     kubectl -n kafka create secret generic vault-keys --from-literal=vault.token=${VAULT_TOKEN} --from-literal=ca.crt="${VAULT_CACERT}"
     ```
 
-1. Then, if using the `kafka-operator` helm chart:
+1. Then, if using the `kafka-operator` Helm chart:
 
     ```bash
     helm install \

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -4,7 +4,7 @@ shorttitle: SSL
 weight: 300
 ---
 
-The Kafka operator makes securing your Apache Kafka cluster with SSL simple.
+The {{< kafka-operator >}} makes securing your Apache Kafka cluster with SSL simple.
 
 ## Enable SSL encryption in Apache Kafka {#enable-ssl}
 
@@ -29,7 +29,7 @@ If `sslSecrets.create` is `false`, the operator will look for the secret at `ssl
 
 ## Using Kafka ACLs with SSL
 
-> Note: The Kafka operator provides only basic ACL support. For a more complete and robust solution, consider using the [Supertubes](/products/supertubes/) product.
+> Note: The {{< kafka-operator >}} provides only basic ACL support. For a more complete and robust solution, consider using the [Supertubes](/products/supertubes/) product.
 > {{< include-headless "doc/kafka-operator-supertubes-intro.md" >}}
 
 If you choose not to enable ACLs for your Apache Kafka cluster, you may still use the `KafkaUser` resource to create new certificates for your applications.

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -143,7 +143,7 @@ An easy way to get up and running quickly with `vault` on your Kubernetes cluste
     kubectl -n kafka create secret generic vault-keys --from-literal=vault.token=${VAULT_TOKEN} --from-literal=ca.crt="${VAULT_CACERT}"
     ```
 
-1. Then, if using the `kafka-operator` Helm chart:
+1. Then, if using the {{< kafka-operator >}} Helm chart:
 
     ```bash
     helm install \

--- a/docs/support.md
+++ b/docs/support.md
@@ -9,8 +9,8 @@ weight: 800
 
 ### Community support
 
-If you encounter problems while using the Kafka operator the documentation does not address, [open an issue](https://github.com/banzaicloud/kafka-operator/issues) or talk to us on the Banzai Cloud Slack channel [#kafka-operator](https://pages.banzaicloud.com/invite-slack).
+If you encounter problems while using the {{< kafka-operator >}} the documentation does not address, [open an issue](https://github.com/banzaicloud/kafka-operator/issues) or talk to us on the Banzai Cloud Slack channel [#kafka-operator](https://pages.banzaicloud.com/invite-slack).
 
 ### Commercial support
 
-If you are using the Kafka operator in a production environment and [require commercial support, contact Banzai Cloud](/contact/), the company backing the development of the Kafka operator.
+If you are using the {{< kafka-operator >}} in a production environment and [require commercial support, contact Banzai Cloud](/contact/), the company backing the development of the {{< kafka-operator >}}.

--- a/docs/support.md
+++ b/docs/support.md
@@ -9,7 +9,7 @@ weight: 800
 
 ### Community support
 
-If you encounter problems while using the {{< kafka-operator >}} the documentation does not address, [open an issue](https://github.com/banzaicloud/kafka-operator/issues) or talk to us on the Banzai Cloud Slack channel [#kafka-operator](https://pages.banzaicloud.com/invite-slack).
+If you encounter problems while using the {{< kafka-operator >}} the documentation does not address, [open an issue](https://github.com/banzaicloud/koperator/issues) or talk to us on the Banzai Cloud Slack channel [#kafka-operator](https://pages.banzaicloud.com/invite-slack).
 
 ### Commercial support
 

--- a/docs/test.md
+++ b/docs/test.md
@@ -6,7 +6,7 @@ weight: 100
 
 ## Create Topic
 
-Topic creation by default is enabled in Kafka, but if it is configured otherwise, you'll need to create a topic first.
+Topic creation by default is enabled in Apache Kafka, but if it is configured otherwise, you'll need to create a topic first.
 
 - You can use the `KafkaTopic` CRD to create a topic called **my-topic** like this:
 

--- a/docs/topics.md
+++ b/docs/topics.md
@@ -32,4 +32,4 @@ kubectl patch -n kafka kafkatopic example-topic --patch '{"spec": {"partitions":
 kafkatopic.kafka.banzaicloud.io/example-topic patched
 ```
 
-> Note: Topics created by the Kafka operator are not enforced in any way. From the Kubernetes perspective, Kafka Topics are external resources.
+> Note: Topics created by the {{< kafka-operator >}} are not enforced in any way. From the Kubernetes perspective, Kafka Topics are external resources.

--- a/docs/troubleshooting/_index.md
+++ b/docs/troubleshooting/_index.md
@@ -1,14 +1,14 @@
 ---
-title: Kafka operator troubleshooting
+title: Troubleshooting the operator
 shorttitle: Troubleshooting
 weight: 400
 ---
 
-The following tips and commands can help you to troubleshoot your Kafka operator installation.
+The following tips and commands can help you to troubleshoot your {{< kafka-operator >}} installation.
 
 ## First things to do
 
-1. Verify that the Kafka operator pod is running. Issue the following command: `kubectl get pods -n kafka|grep kafka-operator`
+1. Verify that the {{< kafka-operator >}} pod is running. Issue the following command: `kubectl get pods -n kafka|grep kafka-operator`
     The output should include a running pod, for example:
 
     ```bash
@@ -170,16 +170,16 @@ Events:            <none>
 
 If you encounter any problems that the documentation does not address, [file an issue](https://github.com/banzaicloud/kafka-operator/issues) or talk to us on the Banzai Cloud Slack channel [#kafka-operator](https://slack.banzaicloud.io/).
 
-[Commercial support]({{< relref "/docs/supertubes/kafka-operator/support.md">}}) is also available for the Kafka operator.
+[Commercial support]({{< relref "/docs/supertubes/kafka-operator/support.md">}}) is also available for the {{< kafka-operator >}}.
 
 Before asking for help, prepare the following information to make troubleshooting faster:
 
-- Kafka operator version
+- {{< kafka-operator >}} version
 - Kubernetes version (**kubectl version**)
-- Helm/chart version (if you installed the Kafka operator with Helm)
-- Kafka operator logs, for example **kubectl logs kafka-operator-operator-6968c67c7b-9d2xq manager -n kafka** and **kubectl logs kafka-operator-operator-6968c67c7b-9d2xq kube-rbac-proxy -n kafka**
+- Helm/chart version (if you installed the {{< kafka-operator >}} with Helm)
+- {{< kafka-operator >}} logs, for example **kubectl logs kafka-operator-operator-6968c67c7b-9d2xq manager -n kafka** and **kubectl logs kafka-operator-operator-6968c67c7b-9d2xq kube-rbac-proxy -n kafka**
 - Kafka broker logs
-- Kafka operator configuration
+- {{< kafka-operator >}} configuration
 - Kafka cluster configuration (**kubectl describe KafkaCluster kafka -n kafka**)
 - Zookeeper configuration (**kubectl describe ZookeeperCluster zookeeper -n zookeeper**)
 - Zookeeper logs (**kubectl logs zookeeper-operator-5c9b597bcc-vkdz9 -n zookeeper**)

--- a/docs/troubleshooting/_index.md
+++ b/docs/troubleshooting/_index.md
@@ -168,7 +168,7 @@ Events:            <none>
 
 ## Getting Support
 
-If you encounter any problems that the documentation does not address, [file an issue](https://github.com/banzaicloud/kafka-operator/issues) or talk to us on the Banzai Cloud Slack channel [#kafka-operator](https://slack.banzaicloud.io/).
+If you encounter any problems that the documentation does not address, [file an issue](https://github.com/banzaicloud/koperator/issues) or talk to us on the Banzai Cloud Slack channel [#kafka-operator](https://slack.banzaicloud.io/).
 
 [Commercial support]({{< relref "/docs/supertubes/kafka-operator/support.md">}}) is also available for the {{< kafka-operator >}}.
 

--- a/docs/troubleshooting/common-errors.md
+++ b/docs/troubleshooting/common-errors.md
@@ -5,10 +5,10 @@ weight: 100
 
 ## Upgrade failed
 
-If you get the following error in the logs of the Kafka operator, update your KafkaCluster CRD. This error typically occurs when you upgrade your Kafka operator to a new version, but forget to update the KafkaCluster CRD.
+If you get the following error in the logs of the {{< kafka-operator >}}, update your KafkaCluster CRD. This error typically occurs when you upgrade your {{< kafka-operator >}} to a new version, but forget to update the KafkaCluster CRD.
 
 ```bash
 Error: UPGRADE FAILED: cannot patch "kafka" with kind KafkaCluster: KafkaCluster.kafka.banzaicloud.io "kafka" is invalid
 ```
 
-The recommended way to upgrade the Kafka operator is to upgrade the KafkaCluster CRD, then update the Kafka operator. For details, see {{% xref "/docs/supertubes/kafka-operator/upgrade-kafka-operator.md" %}}.
+The recommended way to upgrade the {{< kafka-operator >}} is to upgrade the KafkaCluster CRD, then update the {{< kafka-operator >}}. For details, see {{% xref "/docs/supertubes/kafka-operator/upgrade-kafka-operator.md" %}}.

--- a/docs/upgrade-kafka-operator.md
+++ b/docs/upgrade-kafka-operator.md
@@ -1,12 +1,12 @@
 ---
-title: Upgrade the Kafka operator
+title: Upgrade the operator
 shorttitle: Upgrade
 weight: 15
 ---
 
-When upgrading your Kafka operator deployment to a new version, complete the following steps.
+When upgrading your {{< kafka-operator >}} deployment to a new version, complete the following steps.
 
-1. Download the CRDs for the new release from the [Kafka operator releases page](https://github.com/banzaicloud/kafka-operator/releases). They are included in the assets of the release.
+1. Download the CRDs for the new release from the [{{< kafka-operator >}} releases page](https://github.com/banzaicloud/kafka-operator/releases). They are included in the assets of the release.
 
     {{< warning >}}**Hazard of data loss** Do not delete the old CRD from the cluster. Deleting the CRD removes your Kafka cluster.{{< /warning >}}
 
@@ -16,7 +16,7 @@ When upgrading your Kafka operator deployment to a new version, complete the fol
     kubectl replace --validate=false -f https://github.com/banzaicloud/kafka-operator/releases/download/<versionnumber>/kafka-operator.crds.yaml
     ```
 
-1. Update the Kafka operator by running:
+1. Update the {{< kafka-operator >}} by running:
 
     ```bash
     helm repo update

--- a/docs/upgrade-kafka-operator.md
+++ b/docs/upgrade-kafka-operator.md
@@ -6,14 +6,14 @@ weight: 15
 
 When upgrading your {{< kafka-operator >}} deployment to a new version, complete the following steps.
 
-1. Download the CRDs for the new release from the [{{< kafka-operator >}} releases page](https://github.com/banzaicloud/kafka-operator/releases). They are included in the assets of the release.
+1. Download the CRDs for the new release from the [{{< kafka-operator >}} releases page](https://github.com/banzaicloud/koperator/releases). They are included in the assets of the release.
 
     {{< warning >}}**Hazard of data loss** Do not delete the old CRD from the cluster. Deleting the CRD removes your Kafka cluster.{{< /warning >}}
 
 1. Replace the KafkaCluster CRD with the new one on your cluster by running the following command (replace &lt;versionnumber> with the release you are upgrading to, for example, **v0.14.0**).
 
     ```bash
-    kubectl replace --validate=false -f https://github.com/banzaicloud/kafka-operator/releases/download/<versionnumber>/kafka-operator.crds.yaml
+    kubectl replace --validate=false -f https://github.com/banzaicloud/koperator/releases/download/<versionnumber>/kafka-operator.crds.yaml
     ```
 
 1. Update the {{< kafka-operator >}} by running:


### PR DESCRIPTION
Preparations for renaming the Kafka operator and comply with Apache trademark usage. Also requires https://github.com/banzaicloud/banzaicloud.github.io/pull/2229